### PR TITLE
fix: fail fast on JSON parse error

### DIFF
--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -282,6 +282,7 @@ class helpers {
               tree = JSON.parse(body)
             } catch (e) {
               reject(e)
+              return
             }
           }
           if ('message' in tree) {


### PR DESCRIPTION
Previously I added this try/catch which handles JSON parse errors, but this error case (like the others in the function) do not fail fast, as there is no explicit `return`.

I have added it to this case, which prevents the Javascript runtime erroring out, but I wonder if the original intention is to have an explicit `return` on all the error cases (in lines 289 + 293 also).  I am unsure therefore I won't make this change, but encourage this to be considered.

Eg if the owncloud server endpoint is invalid (and doesn't return JSON), this error should occur:
```
SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
```

This error _does_ occur however it doesn't return from the function and continues to assume the `tree` variable is non-null (which  is not the case).
```
TypeError: Cannot use 'in' operator to search for 'message' in null
```
