### PR TITLE
Allow cache control when getting a file

### DIFF
--- a/src/fileManagement.js
+++ b/src/fileManagement.js
@@ -69,7 +69,7 @@ class Files {
    * @returns {Promise.<error>}       string: error message, if any.
    */
   getFileContents (path, options = {}) {
-    return this.helpers._get(this.helpers._buildFullWebDAVURL(path)).then(data => {
+    return this.helpers._get(this.helpers._buildFullWebDAVURL(path), options).then(data => {
       const response = data.response
       const body = data.body
 

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -304,10 +304,11 @@ class helpers {
   /**
    * performs a simple GET request
    * @param   {string}    url     url to perform GET on
+   * @param   {Object} options
    * @returns {Promise.<data>}    object: {response: response, body: request body}
    * @returns {Promise.<error>}   string: error message, if any.
    */
-  _get (url) {
+  _get (url, options = {}) {
     let err = null
 
     if (!this.instance) {
@@ -321,6 +322,11 @@ class helpers {
     const headers = {
       Authorization: this._authHeader,
       'Content-Type': 'application/x-www-form-urlencoded'
+    }
+
+    const noCache = options.noCache || false
+    if (noCache) {
+      headers['Cache-Control'] = 'no-cache'
     }
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
If I edit a file with the markdown editor (or our CERN fork), the PUT request it does receives a reply (at least from OCIS) that instructs the browser to cache the output. This means that if I open the file again, I might not be receiving the latest content that is actually stored in the FS.

I had a quick discussion with Benedikt and proposed allowing a no-cache request.
Here is a possible implementation but please let me know if you have any other idea.